### PR TITLE
fix #68: Set status bar appearance based on theme

### DIFF
--- a/app/src/main/java/com/vishal2376/snaptick/ui/theme/Theme.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/ui/theme/Theme.kt
@@ -59,7 +59,7 @@ fun SnaptickTheme(
 			WindowCompat.getInsetsController(
 				window,
 				view
-			).isAppearanceLightStatusBars = true
+			).isAppearanceLightStatusBars = theme == AppTheme.Light
 		}
 	}
 


### PR DESCRIPTION
## Fix status bar appearing black in dark theme #68

I have implemented a fix that conditionally sets the `WindowInsetsControllerCompat.isAppearanceLightStatusBars` variable based on the app theme.