### PR TITLE
allow previous days tasks to be marked completed in calendar view

### DIFF
--- a/app/src/main/java/com/vishal2376/snaptick/presentation/calender_screen/CalenderScreen.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/presentation/calender_screen/CalenderScreen.kt
@@ -247,7 +247,7 @@ fun CalenderScreen(
 									}
 								},
 								onComplete = {
-									if (task.date >= LocalDate.now()) {
+									if (task.date <= LocalDate.now()) {
 										onEvent(HomeScreenEvent.OnCompleted(it, !task.isCompleted))
 									}
 								},


### PR DESCRIPTION
Hey, I've been using this app for a little bit and I'd really like for the ability to mark previous days tasks as completed in the calendar view. Sometimes I forget to complete the task the day of and there is currently no way to retroactively do so. This small change makes it possible.