### PR TITLE
add de locale to fastlane and improve formatting for en

### DIFF
--- a/fastlane/metadata/android/de/full_description.txt
+++ b/fastlane/metadata/android/de/full_description.txt
@@ -1,0 +1,16 @@
+Wir stellen vor: <i>Snaptick:</i> Ihr einfacher und kostenloser täglicher Aufgabenplaner!
+
+<i>Snaptick</i> ist eine benutzerfreundliche App, die Ihre Produktivität steigern soll, indem sie Ihnen hilft, Ihre Tagespläne mühelos zu organisieren und umzusetzen. Mit einer übersichtlichen und benutzerfreundlichen Oberfläche bietet diese App wichtige Funktionen wie Aufgabenerstellung und -bearbeitung, Aufgabenpriorisierung, einen integrierten Pomodoro-Timer, Sortieroptionen, Aufgabenanalyse und Erinnerungsbenachrichtigungen.
+
+<b>Features</b>
+
+* Aufgaben erstellen und bearbeiten
+* Pomodoro-Timer
+* Aufgabenpriorität verwalten
+* Aufgaben sortieren
+* Freie Zeit anzeigen
+* Aufgabenanalyse
+* Erinnerungsbenachrichtigungen
+* Werbefreie Aufgabenverwaltung
+
+Laden Sie <i>Snaptick</i> jetzt herunter und vereinfachen Sie Ihre tägliche Planung. Steigern Sie Ihre Produktivität mit einem übersichtlichen, werbefreien und effizienten Aufgabenplaner, der sich Ihrem individuellen Stil anpasst. Beginnen Sie noch heute Ihre Reise zu mehr Produktivität!

--- a/fastlane/metadata/android/de/short_description.txt
+++ b/fastlane/metadata/android/de/short_description.txt
@@ -1,0 +1,1 @@
+Steigern Sie Ihre tägliche Produktivität mit Snaptick

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -3,6 +3,7 @@ Introducing Snaptick – Your Simple and Free Daily Task Planner!
 Snaptick is a user-friendly app designed to boost your productivity by helping you organize and achieve your daily plans effortlessly. With a clean and easy-to-use interface, this app offers essential features like task creation and editing, task prioritization, a built-in Pomodoro Timer, sorting options, task analysis, and reminder notifications.
 
 ******************************Features******************************
+
 * 📝 Create and Edit Tasks
 * ⏲️ Pomodoro Timer
 * 💾 Offline Backup


### PR DESCRIPTION
This PR slightly adjusts formatting of the English full description, making it possible to render it as Markdown (supported e.g. at IzzyOnDroid) while keeping it compatible with places not supporting it (e.g. F-Droid.org, PlayStore). It also adds the German (de) locale with short and full description.