### PR TITLE
Updated language chooser

### DIFF
--- a/app/src/main/java/com/vishal2376/snaptick/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/presentation/settings/SettingsScreen.kt
@@ -47,6 +47,7 @@ import com.vishal2376.snaptick.presentation.settings.components.TimePickerOption
 import com.vishal2376.snaptick.ui.theme.SnaptickTheme
 import com.vishal2376.snaptick.util.Constants
 import com.vishal2376.snaptick.util.openUrl
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -170,6 +171,10 @@ fun SettingsScreen(
 
 						R.string.language -> {
 							LanguageOptionComponent(defaultLanguage = appState.language) {
+								scope.launch {
+									sheetState.hide()
+									showBottomSheetById = 0
+								}
 								onEvent(MainEvent.UpdateLanguage(it, context))
 							}
 						}

--- a/app/src/main/java/com/vishal2376/snaptick/presentation/settings/common/TopLanguage.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/presentation/settings/common/TopLanguage.kt
@@ -1,21 +1,25 @@
 package com.vishal2376.snaptick.presentation.settings.common
 
-enum class TopLanguage(val languageCode: String, val emoji: String) {
-	CHINESE("zh", "\uD83C\uDDE8\uD83C\uDDF3"),
-	DANISH("da", "\uD83C\uDDE9\uD83C\uDDF0"),
-	DUTCH("nl", "\uD83C\uDDF3\uD83C\uDDF1"),
-	ENGLISH("en", "\uD83C\uDDEC\uD83C\uDDE7"),
-	FRENCH("fr", "\uD83C\uDDEB\uD83C\uDDF7"),
-	GERMAN("de", "\uD83C\uDDE9\uD83C\uDDEA"),
-	ITALIAN("it", "\uD83C\uDDEE\uD83C\uDDF9"),
-	JAPANESE("ja", "\uD83C\uDDEF\uD83C\uDDF5"),
-	NORWEGIAN("no", "\uD83C\uDDF3\uD83C\uDDF4"),
-	POLISH("pl", "\uD83C\uDDF5\uD83C\uDDF1"),
-	PERSIAN("fa", "\uD83C\uDDE7\uD83C\uDDEB"),
-	PORTUGUESE("pt", "\uD83C\uDDF5\uD83C\uDDF9"),
-	RUSSIAN("ru", "\uD83C\uDDF7\uD83C\uDDFA"),
-	SPANISH("es", "\uD83C\uDDEA\uD83C\uDDF8"),
-	TURKISH("tr", "\uD83C\uDDF9\uD83C\uDDF7"),
-	UKRAINIAN("uk", "\uD83C\uDDFA\uD83C\uDDE6"),
-	VIETNAMESE("vi", "\uD83C\uDDFB\uD83C\uDDF3");
+enum class TopLanguage(
+	val languageCode: String,
+	val endonym: String,
+	val emoji: String
+) {
+	CHINESE("zh", "中文", "\uD83C\uDDE8\uD83C\uDDF3"),
+	DANISH("da", "Dansk", "\uD83C\uDDE9\uD83C\uDDF0"),
+	DUTCH("nl", "Nederlands","\uD83C\uDDF3\uD83C\uDDF1"),
+	ENGLISH("en", "English", "\uD83C\uDDEC\uD83C\uDDE7"),
+	FRENCH("fr", "Français", "\uD83C\uDDEB\uD83C\uDDF7"),
+	GERMAN("de", "Deutsch", "\uD83C\uDDE9\uD83C\uDDEA"),
+	ITALIAN("it", "Italiano", "\uD83C\uDDEE\uD83C\uDDF9"),
+	JAPANESE("ja", "日本語","\uD83C\uDDEF\uD83C\uDDF5"),
+	NORWEGIAN("no", "Norsk bokmål", "\uD83C\uDDF3\uD83C\uDDF4"),
+	POLISH("pl", "Polski", "\uD83C\uDDF5\uD83C\uDDF1"),
+	PERSIAN("fa", "فارسی\u200E", "\uD83C\uDDE7\uD83C\uDDEB"),
+	PORTUGUESE("pt", "Português", "\uD83C\uDDF5\uD83C\uDDF9"),
+	RUSSIAN("ru", "Русский", "\uD83C\uDDF7\uD83C\uDDFA"),
+	SPANISH("es", "Español", "\uD83C\uDDEA\uD83C\uDDF8"),
+	TURKISH("tr", "Türkçe", "\uD83C\uDDF9\uD83C\uDDF7"),
+	UKRAINIAN("uk", "Українська", "\uD83C\uDDFA\uD83C\uDDE6"),
+	VIETNAMESE("vi", "Tiếng Việt", "\uD83C\uDDFB\uD83C\uDDF3");
 }

--- a/app/src/main/java/com/vishal2376/snaptick/presentation/settings/components/LanguageOptionComponent.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/presentation/settings/components/LanguageOptionComponent.kt
@@ -1,5 +1,6 @@
 package com.vishal2376.snaptick.presentation.settings.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -49,7 +50,12 @@ fun LanguageOptionComponent(defaultLanguage: String, onSelect: (String) -> Unit)
 		Column(Modifier.verticalScroll(rememberScrollState())) {
 			TopLanguage.entries.forEach { language ->
 				Row(
-					modifier = Modifier.fillMaxWidth(),
+					modifier = Modifier
+						.fillMaxWidth()
+						.clickable {
+							selectedLanguage = language
+							onSelect(selectedLanguage.languageCode)
+						},
 					verticalAlignment = Alignment.CenterVertically
 				) {
 					RadioButton(
@@ -61,13 +67,7 @@ fun LanguageOptionComponent(defaultLanguage: String, onSelect: (String) -> Unit)
 						colors = RadioButtonDefaults.colors(selectedColor = Blue)
 					)
 					Text(
-						text = language.emoji,
-						style = taskTextStyle,
-						color = MaterialTheme.colorScheme.onPrimaryContainer
-					)
-					Spacer(modifier = Modifier.width(8.dp))
-					Text(
-						text = language.name,
+						text = "${language.emoji}  ${language.endonym}",
 						style = taskTextStyle,
 						color = MaterialTheme.colorScheme.onPrimaryContainer
 					)


### PR DESCRIPTION
I updated language chooser to use language endonyms instead of their english names to improve accessibility, since a person may not know how their language is called in english. 

I also made the whole row with the language string clickable; and made it close on selection. I found it to be the most convenient when using.