### PR TITLE
Security: Prevent ADB Data Extraction and Encrypt Room Database (SQLCipher)

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,9 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="widget">
-        <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2026-04-14T21:44:36.023184600Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Zach\.android\avd\Small_Phone_2.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -6,14 +6,13 @@
       <GradleProjectSettings>
         <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="jbr-17" />
+        <option name="gradleJvm" value="jbr-21" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -124,6 +124,9 @@ dependencies {
 	implementation("androidx.glance:glance-appwidget:1.1.1")
 	implementation("androidx.glance:glance-material3:1.1.1")
 
+	//noinspection Aligned16KB
+	implementation("net.zetetic:android-database-sqlcipher:4.5.4")
+
 
 	testImplementation("junit:junit:4.13.2")
 	androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
 
     <application
         android:name=".SnaptickApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/vishal2376/snaptick/data/local/TaskDatabase.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/data/local/TaskDatabase.kt
@@ -6,6 +6,9 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.vishal2376.snaptick.domain.model.Task
 
+import net.sqlcipher.database.SQLiteDatabase
+import net.sqlcipher.database.SupportFactory
+
 @Database(
 	entities = [Task::class],
 	version = 2,
@@ -23,6 +26,16 @@ abstract class TaskDatabase : RoomDatabase() {
 		 */
 		fun getInstance(context: Context): TaskDatabase {
 			return INSTANCE ?: synchronized(this) {
+
+				// Initialize SQLCipher engine (Required for this version!)
+				SQLiteDatabase.loadLibs(context)
+
+				// Define the encryption key
+				val passphrase = "SuperSecretKey123!".toByteArray()
+
+				// Create the SQLCipher factory
+				val factory = SupportFactory(passphrase)
+
 				val instance = Room.databaseBuilder(
 					context.applicationContext,
 					TaskDatabase::class.java,
@@ -30,6 +43,7 @@ abstract class TaskDatabase : RoomDatabase() {
 				)
 					.fallbackToDestructiveMigration()
 					.addMigrations(MIGRATION_1_2)
+					.openHelperFactory(factory) // ATTACH THE ENCRYPTION FIX HERE
 					.build()
 				INSTANCE = instance
 				instance

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older that API 31
-   See https://developer.android.com/about/versions/12/backup-restore
--->
+<?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <exclude domain="database" path="."/>
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
--->
+<?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude domain="database" path="."/>
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="database" path="."/>
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
### Description of the Vulnerability

While auditing the application, I discovered a compound security vulnerability regarding insecure local data storage. Previously, `android:allowBackup` was enabled by default without explicit exclusion rules. This allowed an attacker with physical access to legacy Android devices (or root access on modern devices) to extract the application's entire sandbox. Because the Room database was utilizing the default SQLite implementation, highly sensitive user tasks were being stored in plaintext and could be read using any SQLite browser.

Since the application already features a robust custom JSON export/import backup system, system-level ADB backups are largely redundant and introduce an unnecessary attack surface.

### Changes Proposed in this PR:

* **Disabled Global Backups:** Set `android:allowBackup="false"` in the `AndroidManifest.xml` to close the perimeter against ADB extraction tools.
* **Granular Backup Rules:** Populated `backup_rules.xml` and `data_extraction_rules.xml` to explicitly exclude the database domain, ensuring that even if system backups are re-enabled in the future, the secure database is never exported to the cloud or via device-to-device transfer.
* **Data-at-Rest Encryption:** Migrated the Room database engine to use **SQLCipher**. 
    * Initialized `SQLiteDatabase.loadLibs(context)` and passed a `SupportFactory` into the Room database builder in `TaskDatabase.kt`.

> **Note for maintainer:** A static passphrase is used in this PR for demonstration, but for production, this should be transitioned to a dynamically generated key stored securely inside the Android Keystore.

### Testing Performed:

* Verified basic CRUD operations (creating, editing, and deleting tasks) remain fully functional by building and testing locally on Android 11 and Android 14 emulators.
* Verified that executing `adb backup` now yields an empty archive for the app's sandbox.
* Verified via root shell extraction that the `local_db` file is now encrypted ciphertext and cannot be read without the passphrase.

> ** Warning:** Because this introduces database encryption, existing users with plaintext databases will trigger the `.fallbackToDestructiveMigration()` flag.