### PR TITLE
feat: add configurable default Pomodoro duration in Settings

### DIFF
--- a/app/src/main/java/com/vishal2376/snaptick/presentation/main/action/MainAction.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/presentation/main/action/MainAction.kt
@@ -51,6 +51,7 @@ sealed interface MainAction {
 	data object SyncAllTasksNow : MainAction
 	data object CompleteOnboarding : MainAction
 	data class UpdateSoundEnabled(val enabled: Boolean) : MainAction
+	data class UpdateDefaultPomodoroDuration(val mins: Int) : MainAction
 	data class CheckForUpdates(val ignoreThrottle: Boolean = false) : MainAction
 	data object DismissUpdateBanner : MainAction
 	data object DismissUpdateStatus : MainAction

--- a/app/src/main/java/com/vishal2376/snaptick/presentation/main/state/MainState.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/presentation/main/state/MainState.kt
@@ -36,6 +36,7 @@ data class MainState(
 	val onboardingCompleted: Boolean = true,
 	val bootResolved: Boolean = false,
 	val soundEnabled: Boolean = true,
+	val defaultPomodoroDuration: Int = 25,
 	val updateAvailable: GitHubRelease? = null,
 	val updateCheckInFlight: Boolean = false,
 	val updateCheckFailed: Boolean = false,

--- a/app/src/main/java/com/vishal2376/snaptick/presentation/main/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/presentation/main/viewmodel/MainViewModel.kt
@@ -209,6 +209,11 @@ class MainViewModel @Inject constructor(
 				settingsStore.setSoundEnabled(action.enabled)
 			}
 
+			is MainAction.UpdateDefaultPomodoroDuration -> persist {
+				_state.update { it.copy(defaultPomodoroDuration = action.mins) }
+				settingsStore.setDefaultPomodoroDuration(action.mins)
+			}
+
 			is MainAction.CheckForUpdates -> viewModelScope.launch {
 				checkForUpdates(ignoreThrottle = action.ignoreThrottle)
 			}
@@ -560,6 +565,11 @@ class MainViewModel @Inject constructor(
 						soundEnabled = v
 					)
 				}
+			}
+		}
+		viewModelScope.launch {
+			settingsStore.defaultPomodoroDurationKey.collect { v ->
+				_state.update { it.copy(defaultPomodoroDuration = v) }
 			}
 		}
 		viewModelScope.launch {

--- a/app/src/main/java/com/vishal2376/snaptick/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/presentation/settings/SettingsScreen.kt
@@ -51,6 +51,7 @@ import com.vishal2376.snaptick.presentation.settings.components.EventImportOptio
 import com.vishal2376.snaptick.presentation.settings.components.LanguageOptionComponent
 import com.vishal2376.snaptick.presentation.settings.components.SettingsCategoryComponent
 import com.vishal2376.snaptick.presentation.settings.components.SleepTimeOptionComponent
+import com.vishal2376.snaptick.presentation.settings.components.PomodoroOptionComponent
 import com.vishal2376.snaptick.presentation.settings.components.SoundOptionComponent
 import com.vishal2376.snaptick.presentation.settings.components.SwipeActionOptionComponent
 import com.vishal2376.snaptick.presentation.settings.components.ThemeOptionComponent
@@ -136,6 +137,11 @@ fun SettingsScreen(
 			title = stringResource(R.string.sounds),
 			resId = R.drawable.ic_clock,
 			onClick = { showBottomSheetById = R.string.sounds }
+		),
+		SettingCategoryItem(
+			title = stringResource(R.string.default_pomodoro_duration),
+			resId = R.drawable.ic_timer,
+			onClick = { showBottomSheetById = R.string.default_pomodoro_duration }
 		),
 		SettingCategoryItem(
 			title = stringResource(R.string.add_widget),
@@ -258,6 +264,13 @@ fun SettingsScreen(
 							SoundOptionComponent(
 								enabled = appState.soundEnabled,
 								onToggle = { onAction(MainAction.UpdateSoundEnabled(it)) },
+							)
+						}
+
+						R.string.default_pomodoro_duration -> {
+							PomodoroOptionComponent(
+								selectedMins = appState.defaultPomodoroDuration,
+								onSelect = { onAction(MainAction.UpdateDefaultPomodoroDuration(it)) },
 							)
 						}
 

--- a/app/src/main/java/com/vishal2376/snaptick/presentation/settings/components/PomodoroOptionComponent.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/presentation/settings/components/PomodoroOptionComponent.kt
@@ -1,0 +1,108 @@
+package com.vishal2376.snaptick.presentation.settings.components
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.vishal2376.snaptick.R
+import com.vishal2376.snaptick.presentation.common.h3TextStyle
+import com.vishal2376.snaptick.presentation.common.taskTextStyle
+import com.vishal2376.snaptick.ui.theme.SnaptickTheme
+
+private val POMODORO_PRESET_MINS = listOf(5, 10, 15, 25, 30, 45, 60)
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun PomodoroOptionComponent(
+    selectedMins: Int,
+    onSelect: (Int) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        SheetTitle(text = stringResource(R.string.choose_pomodoro_duration))
+        FlowRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            POMODORO_PRESET_MINS.forEach { mins ->
+                PomodoroChip(
+                    mins = mins,
+                    selected = mins == selectedMins,
+                    onClick = { onSelect(mins) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PomodoroChip(
+    mins: Int,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val accent = MaterialTheme.colorScheme.primary
+    val baseBg = MaterialTheme.colorScheme.primaryContainer
+    val tintedBg = accent.copy(alpha = 0.12f).compositeOver(baseBg)
+
+    val animatedBg by animateColorAsState(
+        targetValue = if (selected) tintedBg else baseBg,
+        animationSpec = tween(200),
+        label = "chip-bg"
+    )
+    val animatedScale by animateFloatAsState(
+        targetValue = if (selected) 1.06f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+        label = "chip-scale"
+    )
+    val borderColor = if (selected) accent else MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.20f)
+    val borderWidth = if (selected) 2.dp else 1.dp
+
+    Text(
+        text = stringResource(R.string.minutes_format, mins),
+        style = if (selected) h3TextStyle else taskTextStyle,
+        color = if (selected) accent else MaterialTheme.colorScheme.onPrimaryContainer,
+        modifier = Modifier
+            .graphicsLayer { scaleX = animatedScale; scaleY = animatedScale }
+            .background(animatedBg, RoundedCornerShape(50))
+            .border(borderWidth, borderColor, RoundedCornerShape(50))
+            .clickable { onClick() }
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    )
+}
+
+@Preview
+@Composable
+private fun PomodoroOptionComponentPreview() {
+    SnaptickTheme {
+        PomodoroOptionComponent(selectedMins = 25, onSelect = {})
+    }
+}

--- a/app/src/main/java/com/vishal2376/snaptick/util/SettingsStore.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/util/SettingsStore.kt
@@ -43,6 +43,7 @@ class SettingsStore(val context: Context) {
 		private val ONBOARDING_COMPLETED_KEY = booleanPreferencesKey("onboarding_completed_key")
 		private val SOUND_ENABLED_KEY = booleanPreferencesKey("sound_enabled_key")
 		private val LAST_UPDATE_CHECK_AT_KEY = longPreferencesKey("last_update_check_at_key")
+		private val DEFAULT_POMODORO_DURATION_KEY = intPreferencesKey("default_pomodoro_duration_key")
 
 		private const val DEFAULT_LANGUAGE = "en"
 		private val DEFAULT_THEME = AppTheme.Amoled.ordinal
@@ -61,6 +62,7 @@ class SettingsStore(val context: Context) {
 		private const val DEFAULT_CALENDAR_SYNC_CALENDAR_ID = ""
 		private const val DEFAULT_ONBOARDING_COMPLETED = false
 		private const val DEFAULT_SOUND_ENABLED = true
+		const val DEFAULT_POMODORO_DURATION_MINS = 25
 	}
 
 
@@ -136,6 +138,10 @@ class SettingsStore(val context: Context) {
 
 	val lastUpdateCheckAtKey: Flow<Long> = context.dataStore.data.map { preferences ->
 		preferences[LAST_UPDATE_CHECK_AT_KEY] ?: 0L
+	}
+
+	val defaultPomodoroDurationKey: Flow<Int> = context.dataStore.data.map { preferences ->
+		preferences[DEFAULT_POMODORO_DURATION_KEY] ?: DEFAULT_POMODORO_DURATION_MINS
 	}
 
 	suspend fun setTheme(theme: Int) {
@@ -237,6 +243,10 @@ class SettingsStore(val context: Context) {
 
 	suspend fun setLastUpdateCheckAt(epochMillis: Long) {
 		context.dataStore.edit { it[LAST_UPDATE_CHECK_AT_KEY] = epochMillis }
+	}
+
+	suspend fun setDefaultPomodoroDuration(mins: Int) {
+		context.dataStore.edit { it[DEFAULT_POMODORO_DURATION_KEY] = mins }
 	}
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,4 +131,7 @@
     <string name="import_selected">Import selected</string>
     <string name="calendar_permission_required">Calendar permission is required</string>
     <string name="no_writable_calendars_found">No writable calendars found</string>
+    <string name="default_pomodoro_duration">Default Pomodoro Duration</string>
+    <string name="choose_pomodoro_duration">Choose Default Pomodoro Duration</string>
+    <string name="minutes_format">%d min</string>
 </resources>


### PR DESCRIPTION
## Summary

Closes #70

Adds a **Default Pomodoro Duration** option under General settings. The user can pick from preset durations (5, 10, 15, 25, 30, 45, 60 minutes) via an animated chip row shown in a bottom sheet. The selected value is persisted in DataStore and survives app restarts.

## Changes

| File | What changed |
|---|---|
| `SettingsStore.kt` | New `DEFAULT_POMODORO_DURATION_KEY` DataStore key + getter/setter |
| `MainState.kt` | Added `defaultPomodoroDuration: Int = 25` |
| `MainAction.kt` | Added `UpdateDefaultPomodoroDuration(mins: Int)` |
| `MainViewModel.kt` | Collects key on init, handles action |
| `PomodoroOptionComponent.kt` | New bottom sheet component with animated chips |
| `SettingsScreen.kt` | Wires item + bottom sheet case |
| `strings.xml` | Three new string resources |

## Test plan

- [x] Open Settings → General → "Default Pomodoro Duration"
- [x] Bottom sheet opens with chip row showing 5/10/15/25/30/45/60 min
- [x] Selecting a chip animates it (scale + color), dismisses sheet, and persists across restarts
- [x] Default is 25 min if never configured
- [x] All existing settings options still work