### PR TITLE
feat: add postpone button for overdue one-time tasks

### DIFF
--- a/app/src/main/java/com/vishal2376/snaptick/presentation/home_screen/HomeScreen.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/presentation/home_screen/HomeScreen.kt
@@ -433,6 +433,10 @@ fun HomeScreen(
 										onPomodoro = { taskId ->
 											onNavigate("${Routes.PomodoroScreen.name}/$taskId")
 										},
+										onPostpone = { taskId ->
+											onTaskAction(TaskListAction.PostponeTask(taskId))
+											showCustomSnackbar(msg = "Task postponed to tomorrow")
+										},
 										animDelay = if (firstPaintDone) -1
 										else index.coerceAtMost(SnaptickMotion.MAX_STAGGERED_ITEMS) * 110
 									)

--- a/app/src/main/java/com/vishal2376/snaptick/presentation/home_screen/components/TaskComponent.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/presentation/home_screen/components/TaskComponent.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Update
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -68,6 +69,7 @@ fun TaskComponent(
 	onComplete: (Int) -> Unit,
 	onPomodoro: (Int) -> Unit,
 	onDelete: (Int) -> Unit = {},
+	onPostpone: (Int) -> Unit = {},
 	animDelay: Int = 100,
 	is24HourTimeFormat: Boolean = false,
 	today: LocalDate = LocalDate.now()
@@ -269,6 +271,18 @@ fun TaskComponent(
 							painter = painterResource(id = R.drawable.ic_timer),
 							tint = MaterialTheme.colorScheme.onPrimaryContainer,
 							contentDescription = null
+						)
+					}
+				}
+				if (task.date < today && !task.isRepeated && !task.isCompleted) {
+					IconButton(
+						onClick = { onPostpone(task.id) },
+						modifier = Modifier.weight(0.1f)
+					) {
+						Icon(
+							imageVector = Icons.Default.Update,
+							tint = MaterialTheme.colorScheme.onPrimaryContainer,
+							contentDescription = stringResource(R.string.postpone_task)
 						)
 					}
 				}

--- a/app/src/main/java/com/vishal2376/snaptick/presentation/task_list/action/TaskListAction.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/presentation/task_list/action/TaskListAction.kt
@@ -7,4 +7,5 @@ sealed interface TaskListAction {
 	data class SwipeTask(val task: Task) : TaskListAction
 	data class DeleteTask(val taskId: Int) : TaskListAction
 	data object UndoDelete : TaskListAction
+	data class PostponeTask(val taskId: Int) : TaskListAction
 }

--- a/app/src/main/java/com/vishal2376/snaptick/presentation/task_list/viewmodel/TaskListViewModel.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/presentation/task_list/viewmodel/TaskListViewModel.kt
@@ -59,6 +59,14 @@ class TaskListViewModel @Inject constructor(
 			is TaskListAction.UndoDelete -> viewModelScope.launch {
 				deletedTask?.let { task -> repository.insertTask(task) }
 			}
+
+			is TaskListAction.PostponeTask -> viewModelScope.launch {
+				val task = repository.getTaskById(action.taskId) ?: return@launch
+				if (task.isRepeated) return@launch
+				val today = LocalDate.now()
+				val nextDate = if (task.date < today) today else today.plusDays(1)
+				repository.updateTask(task.copy(date = nextDate, isCompleted = false))
+			}
 		}
 	}
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,4 +131,5 @@
     <string name="import_selected">Import selected</string>
     <string name="calendar_permission_required">Calendar permission is required</string>
     <string name="no_writable_calendars_found">No writable calendars found</string>
+    <string name="postpone_task">Postpone task</string>
 </resources>


### PR DESCRIPTION
## Summary

Closes #91

Overdue one-time tasks now show a **postpone** button (↺ icon) alongside the existing delete button. Tapping it:

- Moves the task to **today** if it was in the past
- Moves the task to **tomorrow** if it is already scheduled for today

Repeated tasks are excluded — they manage their own occurrence schedule and should not be rescheduled this way. Completed tasks also hide the button since there is nothing to postpone.

## Changes

| File | Change |
|---|---|
| `TaskListAction.kt` | Added `PostponeTask(taskId: Int)` |
| `TaskListViewModel.kt` | Handler updates `task.date`; skips repeated tasks |
| `TaskComponent.kt` | Renders the postpone `IconButton` for eligible tasks |
| `HomeScreen.kt` | Passes `onPostpone` lambda; shows "Task postponed" snackbar |
| `strings.xml` | Added `postpone_task` string |

## Test plan

- [ ] An overdue task shows postpone + delete buttons
- [ ] Tapping postpone moves the task to today (or tomorrow if today's)
- [ ] Snackbar confirms the action
- [ ] Repeated tasks show no postpone button
- [ ] Completed tasks show no postpone button