### PR TITLE
feat: play a subtle tick at each minute boundary during Pomodoro

### DIFF
--- a/app/src/main/java/com/vishal2376/snaptick/service/PomodoroService.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/service/PomodoroService.kt
@@ -17,6 +17,9 @@ import com.vishal2376.snaptick.data.repositories.TaskRepository
 import com.vishal2376.snaptick.domain.model.Task
 import com.vishal2376.snaptick.presentation.common.utils.formatDurationTimestamp
 import com.vishal2376.snaptick.service.PomodoroService.Companion.startForTask
+import com.vishal2376.snaptick.util.SoundEvent
+import com.vishal2376.snaptick.util.SettingsStore
+import com.vishal2376.snaptick.util.playSound
 import com.vishal2376.snaptick.util.vibrateDevice
 import com.vishal2376.snaptick.widget.presentation.EXTRA_NAVIGATE_TO
 import dagger.hilt.android.AndroidEntryPoint
@@ -61,9 +64,13 @@ class PomodoroService : Service() {
 	@Inject
 	lateinit var repository: TaskRepository
 
+	@Inject
+	lateinit var settingsStore: SettingsStore
+
 	private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 	private var tickerJob: Job? = null
 	private var currentTask: Task? = null
+	private var soundEnabled: Boolean = true
 
 	private val _state = MutableStateFlow(ServiceTimerState())
 	val state: StateFlow<ServiceTimerState> = _state.asStateFlow()
@@ -71,6 +78,13 @@ class PomodoroService : Service() {
 	private val binder = PomodoroBinder(this)
 
 	override fun onBind(intent: Intent?): IBinder = binder
+
+	override fun onCreate() {
+		super.onCreate()
+		scope.launch {
+			settingsStore.soundEnabledKey.collect { soundEnabled = it }
+		}
+	}
 
 	override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
 		ensureChannel()
@@ -197,6 +211,9 @@ class PomodoroService : Service() {
 					vibrateDevice(applicationContext)
 					updateNotification(showCompleted = true)
 				} else {
+					if (newLeft % 60 == 0L) {
+						playSound(applicationContext, SoundEvent.POMODORO_TICK, soundEnabled)
+					}
 					updateNotification()
 				}
 			}

--- a/app/src/main/java/com/vishal2376/snaptick/util/AudioUtil.kt
+++ b/app/src/main/java/com/vishal2376/snaptick/util/AudioUtil.kt
@@ -1,7 +1,9 @@
 package com.vishal2376.snaptick.util
 
 import android.content.Context
+import android.media.AudioManager
 import android.media.MediaPlayer
+import android.media.ToneGenerator
 import androidx.annotation.RawRes
 import com.vishal2376.snaptick.R
 
@@ -17,16 +19,29 @@ private fun playMediaSound(context: Context, @RawRes soundResId: Int) {
 
 fun playSound(context: Context, soundEvent: SoundEvent, enabled: Boolean = true) {
 	if (!enabled) return
-	val soundResId = when (soundEvent) {
-		SoundEvent.TASK_ADDED -> R.raw.task_added
-		SoundEvent.TASK_COMPLETED -> R.raw.task_completed
-		SoundEvent.TASK_DELETED -> R.raw.task_deleted
+	when (soundEvent) {
+		SoundEvent.POMODORO_TICK -> playMinuteTick()
+		else -> {
+			val soundResId = when (soundEvent) {
+				SoundEvent.TASK_ADDED -> R.raw.task_added
+				SoundEvent.TASK_COMPLETED -> R.raw.task_completed
+				SoundEvent.TASK_DELETED -> R.raw.task_deleted
+				SoundEvent.POMODORO_TICK -> return
+			}
+			playMediaSound(context, soundResId)
+		}
 	}
-	playMediaSound(context, soundResId)
+}
+
+private fun playMinuteTick() {
+	val toneGen = ToneGenerator(AudioManager.STREAM_NOTIFICATION, 40)
+	toneGen.startTone(ToneGenerator.TONE_CDMA_ABBR_ALERT, 120)
+	toneGen.release()
 }
 
 enum class SoundEvent {
 	TASK_ADDED,
 	TASK_COMPLETED,
 	TASK_DELETED,
+	POMODORO_TICK,
 }


### PR DESCRIPTION
## Summary

Closes #87

Plays a short, low-volume audio cue at every minute mark while the Pomodoro timer is counting down. This gives the user an ambient signal that time is passing without requiring them to look at the screen.

## Implementation

- Uses Android's built-in `ToneGenerator` (`TONE_CDMA_ABBR_ALERT`, 120 ms, 40% volume on `STREAM_NOTIFICATION`) — no raw audio asset needed.
- Added `SoundEvent.POMODORO_TICK` to the `SoundEvent` enum and a `playMinuteTick()` private helper in `AudioUtil.kt`.
- `PomodoroService` injects `SettingsStore` in `onCreate()` to track the `soundEnabled` preference, then fires the tick when `newLeft % 60 == 0L`.
- Gated entirely by the existing **Enable In-App Sounds** setting — no new UI controls.

## Test plan

- [ ] Start a Pomodoro session; at each minute boundary a soft double-beep plays
- [ ] Disabling "Enable In-App Sounds" silences the tick
- [ ] No tick fires on pause or after completion
- [ ] Existing task-added/completed/deleted sounds still work